### PR TITLE
テーブルの脚とテーブルトップが接するように修正

### DIFF
--- a/artRoom.js
+++ b/artRoom.js
@@ -273,7 +273,9 @@ export function createTable(THREE, width, height, depth, color) {
     
     legPositions.forEach(pos => {
         const leg = new THREE.Mesh(legGeometry, legMaterial);
-        leg.position.set(pos.x, 0, pos.z);
+        // 脚の位置を調整して、テーブルトップと接するようにする
+        // テーブルトップの下部（height - height/10）から始まるようにする
+        leg.position.set(pos.x, height/2, pos.z);
         leg.castShadow = true;
         leg.receiveShadow = true;
         table.add(leg);


### PR DESCRIPTION
テーブルの脚の位置を調整し、テーブルトップと正しく接するようにしました。\n\n## 変更内容\n- テーブルの脚のy座標を0からheight/2に変更\n- これにより脚の上部がテーブルトップの下部と接するようになりました