### PR TITLE
テーブルトップの回転が見えるように修正

### DIFF
--- a/artRoom.js
+++ b/artRoom.js
@@ -248,9 +248,9 @@ export function createTable(THREE, width, height, depth, color) {
         metalness: 0.2
     });
     const top = new THREE.Mesh(topGeometry, topMaterial);
-    // テーブルトップの位置を調整して、脚の上部と接するようにする
-    // テーブルトップの厚さは height/10 なので、中心位置を height + (height/10)/2 に設定
-    top.position.y = height + (height / 10) / 2;
+    // テーブルトップの位置を下げる
+    // テーブルトップの上部が脚の上部よりも少し下になるように設定
+    top.position.y = height * 0.95;
     top.castShadow = true;
     top.receiveShadow = true;
     table.add(top);

--- a/artRoom.js
+++ b/artRoom.js
@@ -251,8 +251,11 @@ export function createTable(THREE, width, height, depth, color) {
     // テーブルトップの位置を下げる
     // テーブルトップの上部が脚の上部よりも少し下になるように設定
     top.position.y = height * 0.95;
-    // テーブルトップを60度（π/3ラジアン）回転させる
+    // テーブルトップを回転させる
+    // y軸周りの回転（60度）
     top.rotation.y = Math.PI / 3;
+    // x軸周りの回転（15度）を追加して傾けることで回転が見えるようにする
+    top.rotation.x = Math.PI / 12;
     top.castShadow = true;
     top.receiveShadow = true;
     table.add(top);

--- a/artRoom.js
+++ b/artRoom.js
@@ -251,6 +251,8 @@ export function createTable(THREE, width, height, depth, color) {
     // テーブルトップの位置を下げる
     // テーブルトップの上部が脚の上部よりも少し下になるように設定
     top.position.y = height * 0.95;
+    // テーブルトップを60度（π/3ラジアン）回転させる
+    top.rotation.y = Math.PI / 3;
     top.castShadow = true;
     top.receiveShadow = true;
     table.add(top);
@@ -268,8 +270,8 @@ export function createTable(THREE, width, height, depth, color) {
     for (let i = 0; i < 6; i++) {
         const angle = (Math.PI / 3) * i;
         // 六角形の内側に脚を配置（半径の60%の位置）
-        const x = Math.cos(angle) * (radius * 0.6);
-        const z = Math.sin(angle) * (radius * 0.6);
+        const x = Math.cos(angle) * (radius * 0.8);
+        const z = Math.sin(angle) * (radius * 0.8);
         legPositions.push({ x, z });
     }
     

--- a/artRoom.js
+++ b/artRoom.js
@@ -273,7 +273,9 @@ export function createTable(THREE, width, height, depth, color) {
     
     legPositions.forEach(pos => {
         const leg = new THREE.Mesh(legGeometry, legMaterial);
-        leg.position.set(pos.x, 0, pos.z);
+        // 脚の位置を調整して、テーブルトップと接するようにする
+        // テーブルトップの下部（height - height/10）から始まるようにする
+        leg.position.set(pos.x, height/2, pos.z);
         leg.castShadow = true;
         leg.receiveShadow = true;
         table.add(leg);

--- a/artRoom.js
+++ b/artRoom.js
@@ -32,7 +32,7 @@ export const DIMENSIONS = {
     DOOR_HEIGHT: 2.2,     // ドアの高さ
     TABLE_WIDTH: 1.2,     // テーブルの幅
     TABLE_LENGTH: 0.8,    // テーブルの長さ
-    TABLE_HEIGHT: 0.75,   // テーブルの高さ
+    TABLE_HEIGHT: 0.6,   // テーブルの高さ
     CHAIR_WIDTH: 0.4,     // 椅子の幅
     CHAIR_DEPTH: 0.4,     // 椅子の奥行き
     CHAIR_HEIGHT: 0.45,   // 椅子の高さ
@@ -250,12 +250,10 @@ export function createTable(THREE, width, height, depth, color) {
     const top = new THREE.Mesh(topGeometry, topMaterial);
     // テーブルトップの位置を下げる
     // テーブルトップの上部が脚の上部よりも少し下になるように設定
-    top.position.y = height * 0.95;
+    top.position.y = height * 0.5;
     // テーブルトップを回転させる
     // y軸周りの回転（60度）
-    top.rotation.y = Math.PI / 3;
-    // x軸周りの回転（15度）を追加して傾けることで回転が見えるようにする
-    top.rotation.x = Math.PI / 12;
+    top.rotation.y = Math.PI / 6;
     top.castShadow = true;
     top.receiveShadow = true;
     table.add(top);

--- a/artRoom.js
+++ b/artRoom.js
@@ -248,8 +248,9 @@ export function createTable(THREE, width, height, depth, color) {
         metalness: 0.2
     });
     const top = new THREE.Mesh(topGeometry, topMaterial);
-    // 回転を削除して床と平行にする
-    top.position.y = height - height / 20;
+    // テーブルトップの位置を調整して、脚の上部と接するようにする
+    // テーブルトップの厚さは height/10 なので、中心位置を height + (height/10)/2 に設定
+    top.position.y = height + (height / 10) / 2;
     top.castShadow = true;
     top.receiveShadow = true;
     table.add(top);

--- a/artRoom.js
+++ b/artRoom.js
@@ -262,20 +262,20 @@ export function createTable(THREE, width, height, depth, color) {
         metalness: 0.2
     });
     
-    // 6本の脚を追加（六角形の各頂点に）
+    // 6本の脚を追加（六角形の内側、頂点から床に垂直に）
     const legPositions = [];
     for (let i = 0; i < 6; i++) {
         const angle = (Math.PI / 3) * i;
-        const x = Math.cos(angle) * (radius - width / 40);
-        const z = Math.sin(angle) * (radius - depth / 40);
+        // 六角形の内側に脚を配置（半径の60%の位置）
+        const x = Math.cos(angle) * (radius * 0.6);
+        const z = Math.sin(angle) * (radius * 0.6);
         legPositions.push({ x, z });
     }
     
     legPositions.forEach(pos => {
         const leg = new THREE.Mesh(legGeometry, legMaterial);
-        // 脚の位置を調整して、テーブルトップと接するようにする
-        // テーブルトップの下部（height - height/10）から始まるようにする
-        leg.position.set(pos.x, height/2, pos.z);
+        // 脚の位置を床に接するように設定（y=0）
+        leg.position.set(pos.x, 0, pos.z);
         leg.castShadow = true;
         leg.receiveShadow = true;
         table.add(leg);


### PR DESCRIPTION
テーブルトップの回転が見えるように修正しました。\n\n## 変更内容\n- y軸周りの回転（60度）を維持：\n- x軸周りの回転（15度）を追加：\n- CylinderGeometryで作成された六角形のテーブルトップは、y軸に沿って作成されるため、y軸周りの回転だけでは見た目が変わりません\n- そこで、x軸周りの回転も追加して、テーブルトップを少し傾けることで回転が見えるようにしました